### PR TITLE
Check for both filename not available and no compress

### DIFF
--- a/source/e32parser.cpp
+++ b/source/e32parser.cpp
@@ -107,7 +107,7 @@ int DecompressPages(uint8_t* bytes, std::ifstream& is);
 
 void E32Parser::DecompressImage()
 {
-    if(!iFileName) // require file for decompression!!!
+    if(!iFileName || !iHdr->iCompressionType) // require file for decompression!!!
         return;
 
     uint32_t buf_size = iHdrJ->iUncompressedSize;


### PR DESCRIPTION
If file not compress (!iHdr->iCompressionType), do not do decompress
If there is no filename, do not do decompress