### PR TITLE
fix linux io.h, writing to const var, not-standard stricmp and strnicmp

### DIFF
--- a/include/portable.h
+++ b/include/portable.h
@@ -306,7 +306,7 @@ struct E32EpocExpSymInfoHdr {
     TInt iSize=0;      // size of this Table
     TInt16 iFlags=0;
     TInt16 iSymCount=0;     // number of symbols
-    const TInt iSymbolTblOffset=sizeof(E32EpocExpSymInfoHdr);   // start of the symbol table - offset from byte 0 of this header
+    TInt iSymbolTblOffset=sizeof(E32EpocExpSymInfoHdr);   // start of the symbol table - offset from byte 0 of this header
     TInt iStringTableSz=0;    // size of the string table
     TInt iStringTableOffset=0;   // start of the string table having names of the symbols - offset from byte 0 of this header
     TInt iDllCount=0;     // Number of dependent DLLs

--- a/source/e32imagefile.cpp
+++ b/source/e32imagefile.cpp
@@ -27,10 +27,11 @@
 #include <cassert>
 #include <iostream>
 #ifndef __LINUX__
-    #include <io.h>
+    #include <sys/io.h>
 #endif
 #include <time.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "h_ver.h"
 #include "e32flags.h"

--- a/source/e32info.cpp
+++ b/source/e32info.cpp
@@ -487,7 +487,7 @@ void E32Info::SymbolInfo()
 
                     if (ordinal == 0 )
                     {
-                        if( impd_offset == (uint32_t)((char*)depOffset - iHdr1->iCodeOffset))
+                        if( impd_offset == *(uint32_t*)((char*)depOffset - iHdr1->iCodeOffset))
                         {
                             /* The offset in import table is same as the offset of this
                              * dependency entry

--- a/source/parametermanager.cpp
+++ b/source/parametermanager.cpp
@@ -35,6 +35,30 @@ using std::endl;
 using std::cerr;
 using std::vector;
 
+static int stricmp(const char* s1, const char* s2) {
+	while (tolower((unsigned char) *s1) == tolower((unsigned char) *s2)) {
+		if (*s1 == '\0')
+			return 0;
+		s1++; s2++;
+	}
+	return (int) tolower((unsigned char) *s1) -
+		(int) tolower((unsigned char) *s2);
+}
+
+static int strnicmp(const char* s1, const char* s2, size_t n) {
+	if (n == 0)
+		return 0;
+
+	do {
+		if (tolower((unsigned char) *s1) != tolower((unsigned char) *s2++))
+			return (int)tolower((unsigned char)*s1) -
+		(int) tolower((unsigned char) *--s2);
+		if (*s1++ == 0)
+			break;
+	} while (--n != 0);
+	return 0;
+}
+
 void ValidateDSOGeneration(ParameterManager *param);
 
 /** The short prefix '-' used for the command line options for the program */


### PR DESCRIPTION
Not tested yet. Fixed compiling errors on Linux gcc-7.5.0.